### PR TITLE
Ensure API calls will not hit Shopify API limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following parameters must be setup within [Wombat](http://wombat.co):
 | shopify_apikey   | Shopify account API key (required) |
 | shopify_password | Shopify account password (required) |
 | shopify_host     | Shopify account host, no 'http://' (required) |
+| shopify_wait     | Shopify API wait between calls, `0.5` for 0.5 second |
 
 ## Webhooks
 

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,4 @@
-worker_processes ENV.fetch('WORKER_PROCESSES', 3).to_i
+worker_processes ENV.fetch('WORKER_PROCESSES', 1).to_i
 timeout 180
 
 preload_app true

--- a/lib/shopify/api_helper.rb
+++ b/lib/shopify/api_helper.rb
@@ -10,17 +10,23 @@ module Shopify
         end
       end
 
+      throttle_api_calls
+
       response = RestClient.get shopify_url + (final_resource resource) + params
       JSON.parse response.force_encoding("utf-8")
     end
 
     def api_post resource, data
+      throttle_api_calls
+
       response = RestClient.post shopify_url + resource, data.to_json,
         :content_type => :json, :accept => :json
       JSON.parse response.force_encoding("utf-8")
     end
 
     def api_put resource, data
+      throttle_api_calls
+
       response = RestClient.put shopify_url + resource, data.to_json,
         :content_type => :json, :accept => :json
       JSON.parse response.force_encoding("utf-8")
@@ -40,6 +46,12 @@ module Shopify
         resource += '.json'
       end
       resource
+    end
+
+    private
+
+    def throttle_api_calls
+      sleep Util.shopify_wait @config if Util.shopify_wait(@config).present?
     end
   end
 end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -52,4 +52,8 @@ class Util
     wombat_config['shopify_host']
   end
 
+  def self.shopify_wait wombat_config
+    wombat_config['shopify_wait'].to_f
+  end
+
 end


### PR DESCRIPTION
- Single thread worker
- Add `shopify_wait` config
